### PR TITLE
Add ... to allow additional argument passthrough

### DIFF
--- a/R/release.R
+++ b/R/release.R
@@ -1,29 +1,32 @@
 #' create a cranlike repo that contains the tagged package
 #' @param .dir directory to create the repo in
 #' @param repo_name repository name to specify in the description
+#' @param ... additional arguments passed to build_pkg
 #' @export
-create_tagged_repo <- function(.dir, repo_name = "pkgpub") {
+create_tagged_repo <- function(.dir, repo_name = "pkgpub", ...) {
   ctag <- current_commit_tag()
-
+  
   # not tagged
   if (is.null(ctag)) {
-   stop("current commit is not tagged")
+    stop("current commit is not tagged")
   }
-  desc <- as.data.frame(read.dcf("DESCRIPTION",fields = "Version"))
+  desc <- as.data.frame(read.dcf("DESCRIPTION", fields = "Version"))
   if (desc$Version != ctag) {
     stop(sprintf("mismatch between git tag (%s) and DESCRIPTION Version (%s)", ctag, desc$Version), call. = FALSE)
   }
-
+  
   repo_dir <- new_cranlike_repo(file.path(.dir, ctag))
-
-  built_dir <- build_pkg(.pkgdir = ".",
-                         types = "source",
-                         origin = sanitize_git_url(git_url()),
-                         repository = repo_name,
-                         addl_meta = list(git_tag = ctag, git_commit = gert::git_info()$commit),
-                         supplement_version = FALSE
-                         )
-
+  
+  built_dir <- build_pkg(
+    .pkgdir = ".",
+    types = "source",
+    origin = sanitize_git_url(git_url()),
+    repository = repo_name,
+    addl_meta = list(git_tag = ctag, git_commit = gert::git_info()$commit),
+    supplement_version = FALSE,
+    ...
+  )
+  
   res <- insert_packages(unlist(built_dir), repo_dir)
   if (!isTRUE(res)) {
     rlang::abort("failure building or inserting package")

--- a/man/create_tagged_repo.Rd
+++ b/man/create_tagged_repo.Rd
@@ -4,12 +4,14 @@
 \alias{create_tagged_repo}
 \title{create a cranlike repo that contains the tagged package}
 \usage{
-create_tagged_repo(.dir, repo_name = "pkgpub")
+create_tagged_repo(.dir, repo_name = "pkgpub", ...)
 }
 \arguments{
 \item{.dir}{directory to create the repo in}
 
 \item{repo_name}{repository name to specify in the description}
+
+\item{...}{additional arguments passed to build_pkg}
 }
 \description{
 create a cranlike repo that contains the tagged package


### PR DESCRIPTION
The original create_tagged_repo() function didn't allow additional arguments.
Output from update
<img width="747" alt="Screenshot 2025-01-30 at 5 56 51 PM" src="https://github.com/user-attachments/assets/be3107f9-f0db-40fd-bdee-4a45b887b794" />
