### PR TITLE
OSflavour param for instert_packages

### DIFF
--- a/R/insert.R
+++ b/R/insert.R
@@ -2,6 +2,7 @@
 #' @param pkgs list of packages to insert
 #' @param repository repository folder to insert
 #' @param archive whether to archive the packages after insertion to prevent duplicates
+#' @param OSflavour optional OS flavour specification, defaults to NULL unless detected as aarch64
 #' @param ... parameters passed to `drat::archivePackages`
 #' @details
 #' repository folder should most likely correspond to the name
@@ -9,7 +10,22 @@
 #' realistically, the time that they need to match when
 #' repos is set in a user session in the `getOption('repos')` field
 #' @export
-insert_packages <- function(pkgs, repository, archive = TRUE, ...) {
+insert_packages <- function(pkgs, repository, archive = TRUE, OSflavour = NULL, ...) {
+
+  # Get system information
+  sys_info <- Sys.info()
+  arch <- R.version$arch
+
+  # Format OSflavour if not provided
+  if (!is.null(OSflavour)) {
+    # Use the provided OSflavour value
+  } else if (arch == "aarch64") {
+    OSflavour <- paste(arch, "apple", tolower(sys_info["sysname"]), 
+                    substr(sys_info["release"], 1, 2), sep="-")
+  } else {
+    OSflavour <- NULL
+  }
+
   if (!dir.exists(repository)) {
     stop("no directory exists at ", repository, call. = FALSE)
   }
@@ -18,7 +34,7 @@ insert_packages <- function(pkgs, repository, archive = TRUE, ...) {
       warning("no package exists at ", .p, call. = FALSE)
       return(FALSE)
     }
-    drat::insertPackage(.p, repodir = repository)
+    drat::insertPackage(.p, repodir = repository, OSflavour = OSflavour)
     return(TRUE)
   })
   message(sprintf("successfully added packages:\n %s", paste0(basename(pkgs[unlist(added_pkgs)]), collapse = ",\n ")))

--- a/R/insert.R
+++ b/R/insert.R
@@ -2,7 +2,7 @@
 #' @param pkgs list of packages to insert
 #' @param repository repository folder to insert
 #' @param archive whether to archive the packages after insertion to prevent duplicates
-#' @param OSflavour optional OS flavour specification, defaults to NULL unless detected as aarch64
+#' @param os_flavor optional os_flavor specification, defaults to NULL unless detected as aarch64
 #' @param ... parameters passed to `drat::archivePackages`
 #' @details
 #' repository folder should most likely correspond to the name
@@ -10,20 +10,20 @@
 #' realistically, the time that they need to match when
 #' repos is set in a user session in the `getOption('repos')` field
 #' @export
-insert_packages <- function(pkgs, repository, archive = TRUE, OSflavour = NULL, ...) {
+insert_packages <- function(pkgs, repository, archive = TRUE, ..., os_flavor = NULL) {
 
   # Get system information
   sys_info <- Sys.info()
   arch <- R.version$arch
 
-  # Format OSflavour if not provided
-  if (!is.null(OSflavour)) {
-    # Use the provided OSflavour value
+  # Format os_flavor if not provided
+  if (!is.null(os_flavor)) {
+    # Use the provided os_flavor value
   } else if (arch == "aarch64") {
-    OSflavour <- paste(arch, "apple", tolower(sys_info["sysname"]), 
+    os_flavor <- paste(arch, "apple", tolower(sys_info["sysname"]), 
                     substr(sys_info["release"], 1, 2), sep="-")
   } else {
-    OSflavour <- NULL
+    os_flavor <- NULL
   }
 
   if (!dir.exists(repository)) {
@@ -34,7 +34,7 @@ insert_packages <- function(pkgs, repository, archive = TRUE, OSflavour = NULL, 
       warning("no package exists at ", .p, call. = FALSE)
       return(FALSE)
     }
-    drat::insertPackage(.p, repodir = repository, OSflavour = OSflavour)
+    drat::insertPackage(.p, repodir = repository, OSflavour = os_flavor)
     return(TRUE)
   })
   message(sprintf("successfully added packages:\n %s", paste0(basename(pkgs[unlist(added_pkgs)]), collapse = ",\n ")))

--- a/man/insert_packages.Rd
+++ b/man/insert_packages.Rd
@@ -4,7 +4,7 @@
 \alias{insert_packages}
 \title{insert packages into a drat repo}
 \usage{
-insert_packages(pkgs, repository, archive = TRUE, ...)
+insert_packages(pkgs, repository, archive = TRUE, OSflavour = NULL, ...)
 }
 \arguments{
 \item{pkgs}{list of packages to insert}
@@ -12,6 +12,8 @@ insert_packages(pkgs, repository, archive = TRUE, ...)
 \item{repository}{repository folder to insert}
 
 \item{archive}{whether to archive the packages after insertion to prevent duplicates}
+
+\item{OSflavour}{optional OS flavour specification, defaults to NULL unless detected as aarch64}
 
 \item{...}{parameters passed to `drat::archivePackages`}
 }

--- a/man/insert_packages.Rd
+++ b/man/insert_packages.Rd
@@ -4,7 +4,7 @@
 \alias{insert_packages}
 \title{insert packages into a drat repo}
 \usage{
-insert_packages(pkgs, repository, archive = TRUE, OSflavour = NULL, ...)
+insert_packages(pkgs, repository, archive = TRUE, ..., os_flavor = NULL)
 }
 \arguments{
 \item{pkgs}{list of packages to insert}
@@ -13,9 +13,9 @@ insert_packages(pkgs, repository, archive = TRUE, OSflavour = NULL, ...)
 
 \item{archive}{whether to archive the packages after insertion to prevent duplicates}
 
-\item{OSflavour}{optional OS flavour specification, defaults to NULL unless detected as aarch64}
-
 \item{...}{parameters passed to `drat::archivePackages`}
+
+\item{os_flavor}{optional os_flavor specification, defaults to NULL unless detected as aarch64}
 }
 \description{
 insert packages into a drat repo


### PR DESCRIPTION
Refactoring to detect if OSflavour is aarch64, provide an optional parameter for a different arch, or default to NULL. OSflavour arg then passed to drat.

Updated `man/insert_packages.rd` with roxygen2 (`devtools::document()`).

Local test example:
```
devtools::load_all(); pkgpub::insert_packages(pkgs = "../tinytex_0.55.tgz", repository = "../insert-test", archive = TRUE)
```
Created the intended folder structure: `insert-test/bin/macosx/big-sur-arm64/contrib/4.4`

Testing with an updated tinytext version for `drat::archivePackages` locally:
```
devtools::load_all(); pkgpub::insert_packages(pkgs = "../tinytex_0.56.2.tgz", repository = "../insert-test", archive = TRUE)
```
Created an Archive folder: 
`insert-test/bin/macosx/big-sur-arm64/contrib/4.4/Archive/tinytex/tinytex_0.55.tgz`

![Screenshot 2025-04-01 at 12 40 36 PM](https://github.com/user-attachments/assets/41e85f07-d3e3-4778-b31c-dae5ccc9823f)


